### PR TITLE
Add blocks to blade component

### DIFF
--- a/resources/views/components/paver.blade.php
+++ b/resources/views/components/paver.blade.php
@@ -1,8 +1,7 @@
 @props([
     'content' => [],
     'config' => [],
-    'locale' => app()->getLocale(),
-    'blocks' => []
+    'locale' => app()->getLocale()
 ])
 
 @php
@@ -10,8 +9,15 @@ $paver = app(Jeffreyvr\Paver\Paver::class);
 
 $paver->locale = $locale;
 
-foreach ($blocks as $block) {
-    $paver->registerBlock($block);
+if(array_key_exists('blocks', $config)) {
+    foreach ($config['blocks'] as $block)
+    {
+        try {
+            $paver->registerBlock($block);
+        } catch (\Throwable $th) {
+            throw new \Exception("Block {$block} cannot be added.");
+        }
+    }
 }
 
 @endphp

--- a/resources/views/components/paver.blade.php
+++ b/resources/views/components/paver.blade.php
@@ -1,13 +1,19 @@
 @props([
     'content' => [],
     'config' => [],
-    'locale' => app()->getLocale()
+    'locale' => app()->getLocale(),
+    'blocks' => []
 ])
 
 @php
 $paver = app(Jeffreyvr\Paver\Paver::class);
 
 $paver->locale = $locale;
+
+foreach ($blocks as $block) {
+    $paver->registerBlock($block);
+}
+
 @endphp
 
 {!! $paver->render($content, $config) !!}


### PR DESCRIPTION
This pull request includes a change to the `resources/views/components/paver.blade.php` file. The change adds a new block registration feature to the `Paver` component, which allows blocks to be registered from the :config parameter if they exist.
This will allow creation of multiple editors with custom blocks

You can load blocks like this:

```
<x-paver :config="[
            'showSaveButton' => true,

            'blocks' => [
                \App\Blocks\Image::class,
            ]
]"/>
```

* Added a check for the existence of 'blocks' in the configuration and registered each block with error handling. (`resources/views/components/paver.blade.php`)